### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request
 from src.services import QFCOnramper, NFTMarketplace, QKDManager, QuantumAIOptimizer
 from src.core import Blockchain, Transaction
+import logging
 
 app = Flask(__name__)
 
@@ -18,7 +19,8 @@ def teleport_nft():
         nft_marketplace.teleport_nft(data["token_id"], data["sender"], data["recipient"])
         return jsonify({"success": True, "message": "NFT teleported successfully."})
     except ValueError as e:
-        return jsonify({"success": False, "error": str(e)})
+        logging.error(f"Error in teleport_nft: {str(e)}")
+        return jsonify({"success": False, "error": "An internal error has occurred."})
 
 @app.route('/onramp/buy', methods=['POST'])
 def buy_qfc():
@@ -27,7 +29,8 @@ def buy_qfc():
         onramper.buy_qfc(data["user"], data["fiat_amount"], data["currency"])
         return jsonify({"success": True, "message": "Fiat converted to QFC successfully."})
     except ValueError as e:
-        return jsonify({"success": False, "error": str(e)})
+        logging.error(f"Error in buy_qfc: {str(e)}")
+        return jsonify({"success": False, "error": "An internal error has occurred."})
 
 @app.route('/qkd/distribute', methods=['POST'])
 def distribute_qkd_key():
@@ -36,7 +39,8 @@ def distribute_qkd_key():
         key = qkd_manager.distribute_key(data["sender"], data["recipient"])
         return jsonify({"success": True, "message": f"QKD key distributed: {key}"})
     except ValueError as e:
-        return jsonify({"success": False, "error": str(e)})
+        logging.error(f"Error in distribute_qkd_key: {str(e)}")
+        return jsonify({"success": False, "error": "An internal error has occurred."})
 
 @app.route('/qkd/teleport', methods=['POST'])
 def teleport_qkd_key():
@@ -45,7 +49,8 @@ def teleport_qkd_key():
         qkd_manager.teleport_qkd_key(data["sender"], data["recipient"])
         return jsonify({"success": True, "message": "QKD key teleported successfully."})
     except ValueError as e:
-        return jsonify({"success": False, "error": str(e)})
+        logging.error(f"Error in teleport_qkd_key: {str(e)}")
+        return jsonify({"success": False, "error": "An internal error has occurred."})
 
 @app.route('/shard/optimize', methods=['POST'])
 def optimize_shard_allocation():
@@ -54,7 +59,8 @@ def optimize_shard_allocation():
         shard_allocations = quantum_ai_optimizer.optimize_shard_allocation(data["transaction_details"])
         return jsonify({"success": True, "shard_allocations": shard_allocations})
     except ValueError as e:
-        return jsonify({"success": False, "error": str(e)})
+        logging.error(f"Error in optimize_shard_allocation: {str(e)}")
+        return jsonify({"success": False, "error": "An internal error has occurred."})
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/1](https://github.com/CreoDAMO/QPOW/security/code-scanning/1)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should log the exception details on the server and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to log the error and return a generic message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the current exception handling blocks to log the exception and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
