### PR TITLE
Fix code scanning alert no. 8: Flask app is run in debug mode

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -63,4 +63,6 @@ def optimize_shard_allocation():
         return jsonify({"success": False, "error": "An internal error has occurred."})
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/8](https://github.com/CreoDAMO/QPOW/security/code-scanning/8)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to control the debug mode based on an environment variable. This way, we can enable debug mode during development and disable it in production.

1. Import the `os` module to access environment variables.
2. Modify the `app.run()` call to set the `debug` parameter based on an environment variable, such as `FLASK_DEBUG`.
3. Set the default value of the `debug` parameter to `False` to ensure that debug mode is disabled if the environment variable is not set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
