### PR TITLE
Fix code scanning alert no. 14: Flask app is run in debug mode

### DIFF
--- a/src/quantum_bridge.py
+++ b/src/quantum_bridge.py
@@ -171,5 +171,7 @@ def not_found_error(error):
 # -------------------- Main Function --------------------
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)
                  


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/14](https://github.com/CreoDAMO/QPOW/security/code-scanning/14)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can enable debug mode during development and disable it in production without changing the code.

We will modify the `app.run()` call to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to run in debug mode. This change will be made in the `src/quantum_bridge.py` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
