### PR TITLE
Fix code scanning alert no. 12: Flask app is run in debug mode

### DIFF
--- a/src/quantum_wallet.py
+++ b/src/quantum_wallet.py
@@ -147,4 +147,6 @@ def not_found_error(error):
 
 # -------------------- Main Function --------------------
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/12](https://github.com/CreoDAMO/QPOW/security/code-scanning/12)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can easily switch between development and production configurations without changing the code.

1. Modify the `app.run` call to use an environment variable to determine whether to run in debug mode.
2. Import the `os` module to access environment variables.
3. Set a default value for the debug mode to `False` to ensure it is not enabled by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
