### PR TITLE
Fix code scanning alert no. 10: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,5 @@ mkdocs==1.6.1
 mkdocs-material==9.5.49
 plantuml-markdown==3.10.4
 python-dotenv==1.0.1
+
+argon2-cffi==23.1.0


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/10](https://github.com/CreoDAMO/QPOW/security/code-scanning/10)

To fix the problem, we need to replace the use of SHA-256 for password hashing with a more secure and computationally expensive algorithm. Argon2 is a good choice for this purpose. We will use the `argon2-cffi` library to hash passwords securely.

Steps to fix the issue:
1. Install the `argon2-cffi` library.
2. Update the `QuantumWallet` class to use Argon2 for hashing passwords.
3. Modify the `__init__` method to hash the password using Argon2.
4. Modify the `authenticate` method to verify the password using Argon2.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
