### PR TITLE
Fix code scanning alert no. 19: Information exposure through an exception

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -71,7 +71,7 @@ def buy_qfc():
         return jsonify({"success": True, "message": "Fiat converted to QFC successfully."})
     except ValueError as e:
         logger.error(f"Error in buy_qfc: {str(e)}")
-        return jsonify({"success": False, "error": str(e)}), 400
+        return jsonify({"success": False, "error": "An internal error has occurred."}), 400
 
 @app.route('/v1/qkd/distribute', methods=['POST'])
 def distribute_qkd_key():
@@ -84,7 +84,7 @@ def distribute_qkd_key():
         return jsonify({"success": True, "message": f"QKD key distributed: {key}"})
     except ValueError as e:
         logger.error(f"Error in distribute_qkd_key: {str(e)}")
-        return jsonify({"success": False, "error": str(e)}), 400
+        return jsonify({"success": False, "error": "An internal error has occurred."}), 400
 
 @app.route('/v1/qkd/teleport', methods=['POST'])
 def teleport_qkd_key():
@@ -97,7 +97,7 @@ def teleport_qkd_key():
         return jsonify({"success": True, "message": "QKD key teleported successfully."})
     except ValueError as e:
         logger.error(f"Error in teleport_qkd_key: {str(e)}")
-        return jsonify({"success": False, "error": str(e)}), 400
+        return jsonify({"success": False, "error": "An internal error has occurred."}), 400
 
 @app.route('/v1/shard/optimize', methods=['POST'])
 def optimize_shard_allocation():
@@ -110,7 +110,7 @@ def optimize_shard_allocation():
         return jsonify({"success": True, "shard_allocations": shard_allocations})
     except ValueError as e:
         logger.error(f"Error in optimize_shard_allocation: {str(e)}")
-        return jsonify({"success": False, "error": str(e)}), 400
+        return jsonify({"success": False, "error": "An internal error has occurred."}), 400
 
 @app.route('/v1/health', methods=['GET'])
 def health_check():


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/19](https://github.com/CreoDAMO/QPOW/security/code-scanning/19)

To fix the problem, we need to modify the code to return a generic error message to the user instead of the actual exception message. The detailed error information should be logged on the server side for debugging purposes. This approach ensures that sensitive information is not exposed to the end user while still allowing developers to access the necessary details for troubleshooting.

- Update the exception handling blocks to return a generic error message to the user.
- Ensure that the detailed error information is logged using the existing `logger.error` calls.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
