### PR TITLE
Fix code scanning alert no. 15: Information exposure through an exception

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -58,7 +58,7 @@ def teleport_nft():
         return jsonify({"success": True, "message": "NFT teleported successfully."})
     except ValueError as e:
         logger.error(f"Error in teleport_nft: {str(e)}")
-        return jsonify({"success": False, "error": str(e)}), 400
+        return jsonify({"success": False, "error": "An internal error has occurred."}), 400
 
 @app.route('/v1/onramp/buy', methods=['POST'])
 def buy_qfc():


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/15](https://github.com/CreoDAMO/QPOW/security/code-scanning/15)

To fix the problem, we need to ensure that the error message returned to the user does not contain sensitive information. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the error handling code in the `teleport_nft` route to return a generic error message while logging the detailed error message on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
