### PR TITLE
Fix code scanning alert no. 13: Information exposure through an exception

### DIFF
--- a/src/quantum_bridge.py
+++ b/src/quantum_bridge.py
@@ -2,6 +2,7 @@ import hashlib
 import time
 import random
 from flask import Flask, jsonify, request, abort
+import logging
 
 # Flask app for API
 app = Flask(__name__)
@@ -137,7 +138,8 @@ def redeem_htlc():
         else:
             return jsonify({"success": False, "message": "Invalid preimage."})
     except TimeoutError as e:
-        return jsonify({"success": False, "error": str(e)}), 400
+        app.logger.error(f"TimeoutError: {str(e)}")
+        return jsonify({"success": False, "error": "A timeout error has occurred."}), 400
 
 
 @app.route('/htlc/check', methods=['GET'])


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/13](https://github.com/CreoDAMO/QPOW/security/code-scanning/13)

To fix the problem, we need to ensure that the exception message is not directly exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the error and return a generic message.

- Modify the exception handling block in the `redeem_htlc` function to log the error message and return a generic error message.
- Add an import for the `logging` module to facilitate logging the error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
