### PR TITLE
Fix code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/src/quantum_wallet.py
+++ b/src/quantum_wallet.py
@@ -121,7 +121,7 @@ def execute_transaction():
         return jsonify({"success": True, "transaction": result})
     except ValueError as e:
         logger.error(f"Transaction error: {str(e)}")
-        return jsonify({"success": False, "error": str(e)}), 400
+        return jsonify({"success": False, "error": "An error occurred during the transaction."}), 400
 
 @app.route('/wallet/balance/<user_id>', methods=['GET'])
 def get_wallet_balance(user_id):


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/11](https://github.com/CreoDAMO/QPOW/security/code-scanning/11)

To fix the problem, we should avoid sending the raw exception message back to the user. Instead, we can log the detailed error message on the server and return a generic error message to the user. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using the server logs.

- Modify the exception handling block to log the detailed error message.
- Return a generic error message to the user instead of the raw exception message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
