### PR TITLE
Fix code scanning alert no. 24: Information exposure through an exception

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -97,7 +97,7 @@ def distribute_qkd_key():
         return jsonify({"success": True, "message": f"QKD key distributed: {key}"})
     except ValueError as e:
         logger.error(f"Error in distribute_qkd_key: {str(e)}")
-        return jsonify({"success": False, "error": str(e)}), 400
+        return jsonify({"success": False, "error": "An error occurred while distributing the QKD key."}), 400
 
 
 @app.route('/v1/qkd/teleport', methods=['POST'])


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/24](https://github.com/CreoDAMO/QPOW/security/code-scanning/24)

To fix the problem, we need to ensure that detailed error messages are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to return a generic error message while logging the detailed error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
