### PR TITLE
Fix code scanning alert no. 23: Information exposure through an exception

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -81,7 +81,7 @@ def buy_qfc():
         return jsonify({"success": True, "message": "Fiat converted to QFC successfully."})
     except ValueError as e:
         logger.error(f"Error in buy_qfc: {str(e)}")
-        return jsonify({"success": False, "error": str(e)}), 400
+        return jsonify({"success": False, "error": "An error occurred while processing your request."}), 400
 
 
 @app.route('/v1/qkd/distribute', methods=['POST'])


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/23](https://github.com/CreoDAMO/QPOW/security/code-scanning/23)

To fix the problem, we need to ensure that the error message returned to the user is generic and does not expose any sensitive information. We will log the detailed error message on the server for debugging purposes and return a generic error message to the user.

- Modify the error handling in the `buy_qfc` function to return a generic error message.
- Ensure that the detailed error message is logged on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
