### PR TITLE
Fix code scanning alert no. 22: Information exposure through an exception

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -65,7 +65,7 @@ def teleport_nft():
         return jsonify({"success": True, "message": "NFT teleported successfully."})
     except ValueError as e:
         logger.error(f"Error in teleport_nft: {str(e)}")
-        return jsonify({"success": False, "error": str(e)}), 400
+        return jsonify({"success": False, "error": "An error occurred while processing your request."}), 400
 
 
 @app.route('/v1/onramp/buy', methods=['POST'])


### PR DESCRIPTION
Fixes [https://github.com/CreoDAMO/QPOW/security/code-scanning/22](https://github.com/CreoDAMO/QPOW/security/code-scanning/22)

To fix the problem, we need to modify the code to return a generic error message to the user instead of the detailed exception message. The detailed exception message should be logged on the server for debugging purposes. This change will ensure that sensitive information is not exposed to external users.

- Modify the `teleport_nft` function to return a generic error message in case of an exception.
- Ensure that the detailed exception message is logged on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
